### PR TITLE
🎨 ✨ 重構首頁使用語意化 HTML 結構並加入 RWD 響應式排版與廣告模擬區塊

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,10 +34,25 @@ export default function Home() {
         </div>
       </header>
 
+      {/* 廣告區塊 1: Header 與冷知識內容之間 */}
+      <div className="bg-yellow-200 border-2 border-dashed border-yellow-400 mx-4 sm:mx-6 lg:mx-8 my-4 sm:my-6 lg:my-8 max-w-screen-md mx-auto w-full">
+        <div className="h-16 sm:h-20 lg:h-24 flex items-center justify-center">
+          <p className="text-sm sm:text-base lg:text-lg font-medium text-yellow-800">這裡是廣告區塊</p>
+        </div>
+      </div>
+
       <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-screen-md mx-auto w-full">
         {fact ? (
           <article className="bg-white rounded-lg shadow-md p-4 sm:p-6 lg:p-8 border border-gray-200">
             <p className="text-lg sm:text-xl lg:text-2xl leading-relaxed text-gray-800 mb-3 sm:mb-4 lg:mb-6">{fact.text}</p>
+            
+            {/* 廣告區塊 2: 冷知識內容段落中（在文字後） */}
+            <div className="bg-green-200 border-2 border-dashed border-green-400 my-4 sm:my-6 lg:my-8">
+              <div className="h-12 sm:h-16 lg:h-20 flex items-center justify-center">
+                <p className="text-xs sm:text-sm lg:text-base font-medium text-green-800">這裡是廣告區塊</p>
+              </div>
+            </div>
+            
             {fact.source && (
               <p className="text-xs sm:text-sm lg:text-base text-gray-500 italic">— {fact.source}</p>
             )}
@@ -48,6 +63,13 @@ export default function Home() {
           </div>
         )}
       </main>
+
+      {/* 廣告區塊 3: Footer 上方 */}
+      <div className="bg-purple-200 border-2 border-dashed border-purple-400 mx-4 sm:mx-6 lg:mx-8 my-4 sm:my-6 lg:my-8 max-w-screen-md mx-auto w-full">
+        <div className="h-16 sm:h-20 lg:h-24 flex items-center justify-center">
+          <p className="text-sm sm:text-base lg:text-lg font-medium text-purple-800">這裡是廣告區塊</p>
+        </div>
+      </div>
 
       <footer className="bg-gray-100 py-4 px-4 sm:py-6 sm:px-6 lg:py-8 lg:px-8 border-t border-gray-200">
         <div className="max-w-screen-md mx-auto text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,18 +27,36 @@ export default function Home() {
   }, []);
 
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold mb-4">🌍 每日冷知識</h1>
-      {fact ? (
-        <article>
-          <p className="text-lg">{fact.text}</p>
-          {fact.source && (
-            <p className="mt-2 text-sm text-gray-500">— {fact.source}</p>
-          )}
-        </article>
-      ) : (
-        <p>載入中...</p>
-      )}
-    </main>
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-blue-600 text-white py-6 px-8 shadow-lg">
+        <h1 className="text-3xl font-bold text-center">🌍 每日冷知識</h1>
+      </header>
+
+      <main className="flex-1 p-8 max-w-4xl mx-auto w-full">
+        {fact ? (
+          <article className="bg-white rounded-lg shadow-md p-8 border border-gray-200">
+            <p className="text-xl leading-relaxed text-gray-800 mb-4">{fact.text}</p>
+            {fact.source && (
+              <p className="text-sm text-gray-500 italic">— {fact.source}</p>
+            )}
+          </article>
+        ) : (
+          <div className="flex justify-center items-center h-64">
+            <p className="text-lg text-gray-600">載入中...</p>
+          </div>
+        )}
+      </main>
+
+      <footer className="bg-gray-100 py-6 px-8 border-t border-gray-200">
+        <div className="max-w-4xl mx-auto text-center">
+          <p className="text-gray-600 text-sm">
+            © 2024 每日冷知識. 保留所有權利.
+          </p>
+          <p className="text-gray-500 text-xs mt-2">
+            讓每一天都充滿驚喜與新知
+          </p>
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,31 +28,33 @@ export default function Home() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-blue-600 text-white py-6 px-8 shadow-lg">
-        <h1 className="text-3xl font-bold text-center">🌍 每日冷知識</h1>
+      <header className="bg-blue-600 text-white py-4 px-4 sm:py-6 sm:px-6 lg:py-8 lg:px-8 shadow-lg">
+        <div className="max-w-screen-md mx-auto">
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-center">🌍 每日冷知識</h1>
+        </div>
       </header>
 
-      <main className="flex-1 p-8 max-w-4xl mx-auto w-full">
+      <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-screen-md mx-auto w-full">
         {fact ? (
-          <article className="bg-white rounded-lg shadow-md p-8 border border-gray-200">
-            <p className="text-xl leading-relaxed text-gray-800 mb-4">{fact.text}</p>
+          <article className="bg-white rounded-lg shadow-md p-4 sm:p-6 lg:p-8 border border-gray-200">
+            <p className="text-lg sm:text-xl lg:text-2xl leading-relaxed text-gray-800 mb-3 sm:mb-4 lg:mb-6">{fact.text}</p>
             {fact.source && (
-              <p className="text-sm text-gray-500 italic">— {fact.source}</p>
+              <p className="text-xs sm:text-sm lg:text-base text-gray-500 italic">— {fact.source}</p>
             )}
           </article>
         ) : (
-          <div className="flex justify-center items-center h-64">
-            <p className="text-lg text-gray-600">載入中...</p>
+          <div className="flex justify-center items-center h-48 sm:h-56 lg:h-64">
+            <p className="text-base sm:text-lg lg:text-xl text-gray-600">載入中...</p>
           </div>
         )}
       </main>
 
-      <footer className="bg-gray-100 py-6 px-8 border-t border-gray-200">
-        <div className="max-w-4xl mx-auto text-center">
-          <p className="text-gray-600 text-sm">
+      <footer className="bg-gray-100 py-4 px-4 sm:py-6 sm:px-6 lg:py-8 lg:px-8 border-t border-gray-200">
+        <div className="max-w-screen-md mx-auto text-center">
+          <p className="text-xs sm:text-sm lg:text-base text-gray-600">
             © 2024 每日冷知識. 保留所有權利.
           </p>
-          <p className="text-gray-500 text-xs mt-2">
+          <p className="text-xs sm:text-xs lg:text-sm text-gray-500 mt-1 sm:mt-2 lg:mt-3">
             讓每一天都充滿驚喜與新知
           </p>
         </div>


### PR DESCRIPTION
## 🤔 為什麼要有這隻 PR?
- 改善首頁的 HTML 語意化結構，提升 SEO 和無障礙性
- 加入響應式設計支援，確保在手機、平板、桌機上都有良好的閱讀體驗
- 預留廣告版位，為後續商業化做準備

## 🚀 這支 PR 做了什麼?
- 語意化 HTML 重構
  - 將原本的 `<main>` 結構重構為完整的語意化佈局
  - 新增 `<header>` 區塊放置網站名稱
  - 保留 `<main>` 區塊作為主要內容區域
  - 新增 `<footer>` 區塊放置版權資訊
- 響應式排版支援
  - 使用 `max-w-screen-md` 限制內容寬度，確保可讀性
  - 加入 `sm:`、`md:`、`lg:` 等 Tailwind 斷點
  - 調整字體大小：手機 `text-lg` → 平板 `sm:text-xl` → 桌機 `lg:text-2xl`
  - 優化間距：手機 `p-4` → 平板 `sm:p-6` → 桌機 `lg:p-8`
- 廣告模擬區塊
  - 在 `Header` 與冷知識內容之間插入黃色廣告區塊
  - 在冷知識內容段落中插入綠色廣告區塊
  - 在 `Footer` 上方插入紫色廣告區塊
  - 每個區塊都支援響應式設計，使用虛線邊框清楚標示

## 📝 補充說明 (沒有的話可以刪掉)
- 保留原有的冷知識邏輯和 API 呼叫機制不變
- 使用不同的背景色區分三個廣告位置
- 所有廣告區塊都支援響應式高度調整
- 確保在各種螢幕尺寸下都能清晰閱讀，排版不擠