### PR TITLE
🚀 實作多語言冷知識系統與日期導向顯示

### DIFF
--- a/app/api/fact/route.ts
+++ b/app/api/fact/route.ts
@@ -29,6 +29,21 @@ export async function GET(req: NextRequest) {
 
   const date = searchParams.get('date');
   const lang = searchParams.get('lang') || 'zh-TW';
+  const random = searchParams.get('random');
+
+  if (random === '1') {
+    // 隨機回傳一則冷知識
+    const idx = Math.floor(Math.random() * facts.length);
+    const fact = facts[idx];
+    const localized = fact.translations[lang as keyof typeof fact.translations] || fact.translations['zh-TW'];
+    return NextResponse.json({
+      error: false,
+      text: localized,
+      source: fact.source || '',
+      id: fact.id,
+      date: fact.date
+    });
+  }
 
   if (!date) {
     const messages = errorMessages[lang] || errorMessages['zh-TW'];

--- a/app/api/fact/route.ts
+++ b/app/api/fact/route.ts
@@ -1,6 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server';
 import facts from '@/data/facts.json';
 
+const errorMessages: Record<string, Record<string, string>> = {
+  'zh-TW': {
+    'noDate': '請提供日期參數（YYYY-MM-DD）',
+    'noFact': '今天沒有冷知識 😢'
+  },
+  'zh-CN': {
+    'noDate': '请提供日期参数（YYYY-MM-DD）',
+    'noFact': '今天没有冷知识 😢'
+  },
+  'en': {
+    'noDate': 'Please provide date parameter (YYYY-MM-DD)',
+    'noFact': 'No fact for today 😢'
+  },
+  'ja': {
+    'noDate': '日付パラメータを提供してください（YYYY-MM-DD）',
+    'noFact': '今日の冷知識はありません 😢'
+  },
+  'ko': {
+    'noDate': '날짜 매개변수를 제공해주세요 (YYYY-MM-DD)',
+    'noFact': '오늘의 냉지식이 없습니다 😢'
+  }
+};
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
 
@@ -8,18 +31,28 @@ export async function GET(req: NextRequest) {
   const lang = searchParams.get('lang') || 'zh-TW';
 
   if (!date) {
-    return NextResponse.json({ text: '請提供日期參數（YYYY-MM-DD）' });
+    const messages = errorMessages[lang] || errorMessages['zh-TW'];
+    return NextResponse.json({ 
+      error: true,
+      text: messages.noDate
+    });
   }
 
   const fact = facts.find((f) => f.date === date);
 
   if (!fact) {
-    return NextResponse.json({ text: '今天沒有冷知識 😢' });
+    const messages = errorMessages[lang] || errorMessages['zh-TW'];
+    return NextResponse.json({ 
+      error: true,
+      notFound: true,
+      text: messages.noFact
+    });
   }
 
   const localized = fact.translations[lang as keyof typeof fact.translations] || fact.translations['zh-TW'];
 
   return NextResponse.json({
+    error: false,
     text: localized,
     source: fact.source || '',
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { getFactByDate, getRandomFact, Language } from '../src/utils/facts';
 
 type Fact = {
   text: string;
   source?: string;
   error?: boolean;
   notFound?: boolean;
+  id?: string;
+  date?: string;
 };
-
-type Language = 'zh-TW' | 'zh-CN' | 'en' | 'ja' | 'ko';
 
 const fallbackMessages: Record<Language, string> = {
   'zh-TW': '今天還沒有冷知識喔，明天再來看看！',
@@ -39,35 +40,19 @@ export default function Home() {
   const fetchFact = async (date: string, lang: Language, random = false) => {
     setIsLoading(true);
     try {
-      const url = random
-        ? `/api/fact?lang=${lang}&random=1`
-        : `/api/fact?date=${date}&lang=${lang}`;
-      const response = await fetch(url);
-      const data = await response.json();
-      
-      if (data.error && data.notFound) {
-        // 找不到該日期的冷知識，顯示 fallback 訊息
-        setFact({ 
-          text: fallbackMessages[lang],
-          error: true,
-          notFound: true
-        });
-      } else if (data.error) {
-        // 其他錯誤
-        setFact({ 
-          text: fallbackMessages[lang],
-          error: true
-        });
+      let factData: Fact | null = null;
+      if (random) {
+        factData = getRandomFact(lang);
       } else {
-        // 成功找到冷知識
-        setFact(data);
+        factData = getFactByDate(date, lang);
+      }
+      if (!factData) {
+        setFact({ text: fallbackMessages[lang], error: true, notFound: true });
+      } else {
+        setFact(factData);
       }
     } catch {
-      // 網路錯誤
-      setFact({ 
-        text: fallbackMessages[lang],
-        error: true
-      });
+      setFact({ text: fallbackMessages[lang], error: true });
     } finally {
       setIsLoading(false);
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -172,12 +172,8 @@ export default function Home() {
             <h1 className="inline-block">
               <span className="inline-block font-mono font-black text-2xl sm:text-3xl lg:text-4xl tracking-wider mb-2 drop-shadow-lg">
                 <span className="inline-block animate-bounce" style={{ animationDelay: '0s', animationDuration: '2s' }}>📘</span>
-                <span className="mx-2">{t('title')}</span>
+                <span className="mx-2">{t('subtitle')}</span>
                 <span className="inline-block animate-bounce" style={{ animationDelay: '1s', animationDuration: '2s' }}>⭐️</span>
-              </span>
-              <br />
-              <span className="inline-block font-mono font-black text-xl sm:text-2xl lg:text-3xl tracking-wider drop-shadow-lg">
-                🌍 {t('subtitle')} 🎮
               </span>
             </h1>
             <p className="font-mono font-semibold text-blue-100 text-xs sm:text-sm lg:text-base mt-3 sm:mt-4 tracking-wide drop-shadow-md">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { getFactByDate, getRandomFact, Language } from '../src/utils/facts';
+import { useTranslation } from '../src/i18n/translations';
 
 type Fact = {
   text: string;
@@ -20,14 +21,6 @@ const fallbackMessages: Record<Language, string> = {
   'ko': '오늘의 냉지식이 아직 없습니다, 내일 다시 와주세요!'
 };
 
-const changeFactButtonText: Record<Language, string> = {
-  'zh-TW': '換一則冷知識',
-  'zh-CN': '换一则冷知识',
-  'en': 'Another Fact',
-  'ja': '別の冷知識',
-  'ko': '다른 냉지식'
-};
-
 export default function Home() {
   const [fact, setFact] = useState<Fact | null>(null);
   const [currentDate, setCurrentDate] = useState<string>('');
@@ -36,6 +29,8 @@ export default function Home() {
   const [currentLanguage, setCurrentLanguage] = useState<Language>('zh-TW');
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isRandom, setIsRandom] = useState<boolean>(false);
+
+  const { t } = useTranslation(currentLanguage);
 
   const fetchFact = async (date: string, lang: Language, random = false) => {
     setIsLoading(true);
@@ -108,12 +103,20 @@ export default function Home() {
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('zh-TW', {
+    const localeMap: Record<Language, string> = {
+      'zh-TW': 'zh-TW',
+      'zh-CN': 'zh-CN',
+      'en': 'en-US',
+      'ja': 'ja-JP',
+      'ko': 'ko-KR'
+    };
+    
+    return new Intl.DateTimeFormat(localeMap[currentLanguage], {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
       weekday: 'long'
-    });
+    }).format(date);
   };
 
   const handleLanguageChange = (newLang: Language) => {
@@ -169,16 +172,16 @@ export default function Home() {
             <h1 className="inline-block">
               <span className="inline-block font-mono font-black text-2xl sm:text-3xl lg:text-4xl tracking-wider mb-2 drop-shadow-lg">
                 <span className="inline-block animate-bounce" style={{ animationDelay: '0s', animationDuration: '2s' }}>📘</span>
-                <span className="mx-2">DAILY FACT</span>
+                <span className="mx-2">{t('title')}</span>
                 <span className="inline-block animate-bounce" style={{ animationDelay: '1s', animationDuration: '2s' }}>⭐️</span>
               </span>
               <br />
               <span className="inline-block font-mono font-black text-xl sm:text-2xl lg:text-3xl tracking-wider drop-shadow-lg">
-                🌍 每日冷知識 🎮
+                🌍 {t('subtitle')} 🎮
               </span>
             </h1>
             <p className="font-mono font-semibold text-blue-100 text-xs sm:text-sm lg:text-base mt-3 sm:mt-4 tracking-wide drop-shadow-md">
-              🎯 每天一則冷知識，讓生活更有趣 🎯
+              🎯 {t('tagline')} 🎯
             </p>
           </div>
         </div>
@@ -190,7 +193,7 @@ export default function Home() {
           <div className="bg-yellow-200 border-2 border-dashed border-yellow-400 rounded-lg">
             <div className="h-16 sm:h-20 lg:h-24 flex items-center justify-center">
               <p className="text-sm sm:text-base lg:text-lg font-medium text-yellow-800">
-                這裡是頂部廣告區塊
+                {t('topAdZone')}
               </p>
             </div>
           </div>
@@ -223,11 +226,11 @@ export default function Home() {
                   onChange={(e) => handleLanguageChange(e.target.value as Language)}
                   className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-lg px-3 py-2 text-white text-xs sm:text-sm font-mono focus:outline-none focus:ring-2 focus:ring-white/50"
                 >
-                  <option value="zh-TW" className="text-gray-800">繁體中文</option>
-                  <option value="zh-CN" className="text-gray-800">简体中文</option>
-                  <option value="en" className="text-gray-800">English</option>
-                  <option value="ja" className="text-gray-800">日本語</option>
-                  <option value="ko" className="text-gray-800">한국어</option>
+                  <option value="zh-TW" className="text-gray-800">{t('languages.zh-TW')}</option>
+                  <option value="zh-CN" className="text-gray-800">{t('languages.zh-CN')}</option>
+                  <option value="en" className="text-gray-800">{t('languages.en')}</option>
+                  <option value="ja" className="text-gray-800">{t('languages.ja')}</option>
+                  <option value="ko" className="text-gray-800">{t('languages.ko')}</option>
                 </select>
               </div>
             </div>
@@ -241,7 +244,7 @@ export default function Home() {
               style={{ animationDelay: '0.2s' }}
             >
               <span className="text-lg sm:text-xl transition-transform duration-300 group-hover:scale-110">🔄</span>
-              <span>{changeFactButtonText[currentLanguage]}</span>
+              <span>{t('changeFact')}</span>
             </button>
           </section>
 
@@ -253,7 +256,7 @@ export default function Home() {
                   <div className="text-center">
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
                     <p className="font-mono text-base sm:text-lg lg:text-xl text-gray-600">
-                      載入中...
+                      {t('loading')}
                     </p>
                   </div>
                 </div>
@@ -271,7 +274,7 @@ export default function Home() {
                       {fact.error && fact.notFound ? '📭' : '📖'}
                     </span>
                     <h2 className="font-mono font-bold text-sm sm:text-base lg:text-lg tracking-wide uppercase">
-                      {fact.error && fact.notFound ? 'No Fact Today' : 'Today\'s Fact'}
+                      {fact.error && fact.notFound ? t('noFactTodayHeader') : t('todayFact')}
                     </h2>
                     <span className="text-lg sm:text-xl lg:text-2xl">
                       {fact.error && fact.notFound ? '😊' : '✨'}
@@ -300,7 +303,7 @@ export default function Home() {
                       <div className="bg-green-100 border-2 border-dashed border-green-400 rounded-lg">
                         <div className="h-12 sm:h-16 lg:h-20 flex items-center justify-center">
                           <p className="text-xs sm:text-sm lg:text-base font-medium text-green-800">
-                            這裡是內容中廣告區塊
+                            {t('middleAdZone')}
                           </p>
                         </div>
                       </div>
@@ -337,19 +340,19 @@ export default function Home() {
               <div className="flex items-center justify-center gap-3 mb-4">
                 <span className="text-2xl sm:text-3xl lg:text-4xl animate-bounce">🌙</span>
                 <h2 className="font-mono font-bold text-xl sm:text-2xl lg:text-3xl tracking-wide">
-                  See you tomorrow!
+                  {t('seeYouTomorrow')}
                 </h2>
                 <span className="text-2xl sm:text-3xl lg:text-4xl animate-pulse">⏰</span>
               </div>
               
               <p className="text-pink-100 text-sm sm:text-base lg:text-lg mb-6 font-medium">
-                明天還會有新的冷知識等著你，記得回來看看喔！
+                {t('tomorrowMessage')}
               </p>
               
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
                 <div className="bg-white/20 backdrop-blur-sm rounded-full px-6 py-3 border border-white/30">
                   <div className="text-center">
-                    <p className="text-xs sm:text-sm text-pink-100 mb-1">距離明天還有</p>
+                    <p className="text-xs sm:text-sm text-pink-100 mb-1">{t('timeUntilTomorrow')}</p>
                     <div className="font-mono font-bold text-lg sm:text-xl lg:text-2xl text-white tracking-wider">
                       {timeUntilMidnight}
                     </div>
@@ -359,7 +362,7 @@ export default function Home() {
                 <div className="flex items-center gap-2">
                   <span className="text-lg sm:text-xl">🎯</span>
                   <span className="text-sm sm:text-base text-pink-100 font-medium">
-                    準時更新
+                    {t('onTimeUpdate')}
                   </span>
                 </div>
               </div>
@@ -376,7 +379,7 @@ export default function Home() {
                 style={{ animationDelay: '0.4s' }}
               >
                 <span className="text-lg sm:text-xl transition-transform duration-300 group-hover:scale-110">📤</span>
-                <span>Share</span>
+                <span>{t('share')}</span>
               </button>
             </div>
           </section>
@@ -386,7 +389,7 @@ export default function Home() {
             <div className="fixed top-4 right-4 bg-green-500 text-white px-4 py-2 rounded-lg shadow-lg z-50 animate-fade-in-up">
               <div className="flex items-center gap-2">
                 <span>✅</span>
-                <span className="text-sm font-medium">連結已複製到剪貼簿！</span>
+                <span className="text-sm font-medium">{t('shareSuccess')}</span>
               </div>
             </div>
           )}
@@ -400,7 +403,7 @@ export default function Home() {
           <div className="bg-purple-200 border-2 border-dashed border-purple-400 rounded-lg">
             <div className="h-16 sm:h-20 lg:h-24 flex items-center justify-center">
               <p className="text-sm sm:text-base lg:text-lg font-medium text-purple-800">
-                這裡是底部廣告區塊
+                {t('bottomAdZone')}
               </p>
             </div>
           </div>
@@ -412,10 +415,10 @@ export default function Home() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
           <div className="text-center">
             <p className="text-sm sm:text-base text-gray-300 mb-2">
-              © 2024 每日冷知識. 保留所有權利.
+              {t('copyright')}
             </p>
             <p className="text-xs sm:text-sm text-gray-400">
-              讓每一天都充滿驚喜與新知
+              {t('footerTagline')}
             </p>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,14 @@ const fallbackMessages: Record<Language, string> = {
   'ko': '오늘의 냉지식이 아직 없습니다, 내일 다시 와주세요!'
 };
 
+const changeFactButtonText: Record<Language, string> = {
+  'zh-TW': '換一則冷知識',
+  'zh-CN': '换一则冷知识',
+  'en': 'Another Fact',
+  'ja': '別の冷知識',
+  'ko': '다른 냉지식'
+};
+
 export default function Home() {
   const [fact, setFact] = useState<Fact | null>(null);
   const [currentDate, setCurrentDate] = useState<string>('');
@@ -26,11 +34,15 @@ export default function Home() {
   const [showShareToast, setShowShareToast] = useState<boolean>(false);
   const [currentLanguage, setCurrentLanguage] = useState<Language>('zh-TW');
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isRandom, setIsRandom] = useState<boolean>(false);
 
-  const fetchFact = async (date: string, lang: Language) => {
+  const fetchFact = async (date: string, lang: Language, random = false) => {
     setIsLoading(true);
     try {
-      const response = await fetch(`/api/fact?date=${date}&lang=${lang}`);
+      const url = random
+        ? `/api/fact?lang=${lang}&random=1`
+        : `/api/fact?date=${date}&lang=${lang}`;
+      const response = await fetch(url);
       const data = await response.json();
       
       if (data.error && data.notFound) {
@@ -84,7 +96,8 @@ export default function Home() {
     }
     
     setCurrentLanguage(defaultLang);
-    fetchFact(localDate, defaultLang);
+    setIsRandom(false);
+    fetchFact(localDate, defaultLang, false);
   }, []);
 
   useEffect(() => {
@@ -121,8 +134,17 @@ export default function Home() {
   const handleLanguageChange = (newLang: Language) => {
     setCurrentLanguage(newLang);
     if (currentDate) {
-      fetchFact(currentDate, newLang);
+      if (isRandom) {
+        fetchFact(currentDate, newLang, true);
+      } else {
+        fetchFact(currentDate, newLang, false);
+      }
     }
+  };
+
+  const handleChangeFact = () => {
+    setIsRandom(true);
+    fetchFact(currentDate, currentLanguage, true);
   };
 
   const handleShare = async () => {
@@ -224,6 +246,18 @@ export default function Home() {
                 </select>
               </div>
             </div>
+          </section>
+
+          {/* Change Fact Button */}
+          <section className="flex justify-center">
+            <button
+              onClick={handleChangeFact}
+              className="group flex items-center justify-center gap-2 px-6 py-2 bg-gradient-to-r from-pink-500 to-orange-400 text-white rounded-lg hover:from-pink-600 hover:to-orange-500 transform transition-all duration-300 hover:scale-105 hover:shadow-lg text-sm sm:text-base font-medium animate-fade-in-up mb-2"
+              style={{ animationDelay: '0.2s' }}
+            >
+              <span className="text-lg sm:text-xl transition-transform duration-300 group-hover:scale-110">🔄</span>
+              <span>{changeFactButtonText[currentLanguage]}</span>
+            </button>
           </section>
 
           {/* Main Fact Card */}

--- a/data/facts.json
+++ b/data/facts.json
@@ -10,5 +10,29 @@
       "ko": "문어는 심장이 세 개 있으며, 수영할 때 두 개는 멈춘다는 사실을 알고 있었나요？"
     },
     "source": "科學人 2019年6月號"
+  },
+  {
+    "id": "20250705-001",
+    "date": "2025-07-05",
+    "translations": {
+      "zh-TW": "你知道嗎？蜂蜜是唯一不會腐壞的食物，考古學家曾在古埃及金字塔中發現了3000年前的蜂蜜，仍然可以食用。",
+      "zh-CN": "你知道吗？蜂蜜是唯一不会腐败的食物，考古学家曾在古埃及金字塔中发现了3000年前的蜂蜜，仍然可以食用。",
+      "en": "Did you know? Honey is the only food that never spoils. Archaeologists found 3000-year-old honey in ancient Egyptian pyramids that was still edible.",
+      "ja": "蜂蜜は腐らない唯一の食品であることをご存じでしたか？考古学者は古代エジプトのピラミッドで3000年前の蜂蜜を発見し、まだ食べられる状態でした。",
+      "ko": "꿀은 부패하지 않는 유일한 음식이라는 사실을 알고 있었나요？ 고고학자들은 고대 이집트 피라미드에서 3000년 전의 꿀을 발견했는데, 여전히 먹을 수 있는 상태였습니다."
+    },
+    "source": "國家地理雜誌 2020年3月號"
+  },
+  {
+    "id": "20250706-001",
+    "date": "2025-07-06",
+    "translations": {
+      "zh-TW": "你知道嗎？香蕉其實是漿果，而草莓卻不是漿果。在植物學分類中，香蕉屬於漿果類，而草莓屬於聚合果。",
+      "zh-CN": "你知道吗？香蕉其实是浆果，而草莓却不是浆果。在植物学分类中，香蕉属于浆果类，而草莓属于聚合果。",
+      "en": "Did you know? Bananas are actually berries, while strawberries are not. In botanical classification, bananas are berries, while strawberries are aggregate fruits.",
+      "ja": "バナナは実はベリー類で、イチゴはベリー類ではないことをご存じでしたか？植物学の分類では、バナナはベリー類に属し、イチゴは集合果に属します。",
+      "ko": "바나나는 실제로는 베리이고, 딸기는 베리가 아니라는 사실을 알고 있었나요？ 식물학적 분류에서 바나나는 베리에 속하고, 딸기는 집합과에 속합니다."
+    },
+    "source": "科學月刊 2021年8月號"
   }
 ]

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,217 @@
+export type Language = 'zh-TW' | 'zh-CN' | 'en' | 'ja' | 'ko';
+
+export const translations = {
+  'zh-TW': {
+    // Header
+    title: 'DAILY FACT',
+    subtitle: '每日冷知識',
+    tagline: '每天一則冷知識，讓生活更有趣',
+    
+    // Language options
+    languages: {
+      'zh-TW': '繁體中文',
+      'zh-CN': '简体中文',
+      'en': 'English',
+      'ja': '日本語',
+      'ko': '한국어'
+    },
+    
+    // Buttons
+    changeFact: '換一則冷知識',
+    share: '分享',
+    
+    // Status messages
+    loading: '載入中...',
+    noFactToday: '尚無今日冷知識',
+    fallbackMessage: '今天還沒有冷知識喔，明天再來看看！',
+    
+    // Card headers
+    todayFact: '今日冷知識',
+    noFactTodayHeader: '今日無冷知識',
+    
+    // Tomorrow section
+    seeYouTomorrow: '明天見！',
+    tomorrowMessage: '明天還會有新的冷知識等著你，記得回來看看喔！',
+    timeUntilTomorrow: '距離明天還有',
+    onTimeUpdate: '準時更新',
+    
+    // Share toast
+    shareSuccess: '連結已複製到剪貼簿！',
+    
+    // Footer
+    copyright: '© 2024 每日冷知識. 保留所有權利.',
+    footerTagline: '讓每一天都充滿驚喜與新知',
+    
+    // Ad zones
+    topAdZone: '這裡是頂部廣告區塊',
+    middleAdZone: '這裡是內容中廣告區塊',
+    bottomAdZone: '這裡是底部廣告區塊'
+  },
+  
+  'zh-CN': {
+    title: 'DAILY FACT',
+    subtitle: '每日冷知识',
+    tagline: '每天一则冷知识，让生活更有趣',
+    
+    languages: {
+      'zh-TW': '繁體中文',
+      'zh-CN': '简体中文',
+      'en': 'English',
+      'ja': '日本語',
+      'ko': '한국어'
+    },
+    
+    changeFact: '换一则冷知识',
+    share: '分享',
+    
+    loading: '加载中...',
+    noFactToday: '暂无今日冷知识',
+    fallbackMessage: '今天还没有冷知识哦，明天再来看吧！',
+    
+    todayFact: '今日冷知识',
+    noFactTodayHeader: '今日无冷知识',
+    
+    seeYouTomorrow: '明天见！',
+    tomorrowMessage: '明天还会有新的冷知识等着你，记得回来看吧！',
+    timeUntilTomorrow: '距离明天还有',
+    onTimeUpdate: '准时更新',
+    
+    shareSuccess: '链接已复制到剪贴板！',
+    
+    copyright: '© 2024 每日冷知识. 保留所有权利.',
+    footerTagline: '让每一天都充满惊喜与新知',
+    
+    topAdZone: '这里是顶部广告区块',
+    middleAdZone: '这里是内容中广告区块',
+    bottomAdZone: '这里是底部广告区块'
+  },
+  
+  'en': {
+    title: 'DAILY FACT',
+    subtitle: 'Daily Facts',
+    tagline: 'One fact a day keeps boredom away',
+    
+    languages: {
+      'zh-TW': '繁體中文',
+      'zh-CN': '简体中文',
+      'en': 'English',
+      'ja': '日本語',
+      'ko': '한국어'
+    },
+    
+    changeFact: 'Another Fact',
+    share: 'Share',
+    
+    loading: 'Loading...',
+    noFactToday: 'No fact for today',
+    fallbackMessage: 'No fact for today yet, come back tomorrow!',
+    
+    todayFact: 'Today\'s Fact',
+    noFactTodayHeader: 'No Fact Today',
+    
+    seeYouTomorrow: 'See you tomorrow!',
+    tomorrowMessage: 'There will be new facts waiting for you tomorrow, remember to come back!',
+    timeUntilTomorrow: 'Time until tomorrow',
+    onTimeUpdate: 'On time update',
+    
+    shareSuccess: 'Link copied to clipboard!',
+    
+    copyright: '© 2024 Daily Facts. All rights reserved.',
+    footerTagline: 'Make every day full of surprises and new knowledge',
+    
+    topAdZone: 'Top Ad Zone',
+    middleAdZone: 'Middle Ad Zone',
+    bottomAdZone: 'Bottom Ad Zone'
+  },
+  
+  'ja': {
+    title: 'DAILY FACT',
+    subtitle: '毎日の冷知識',
+    tagline: '毎日一つの冷知識で、生活をより楽しく',
+    
+    languages: {
+      'zh-TW': '繁體中文',
+      'zh-CN': '简体中文',
+      'en': 'English',
+      'ja': '日本語',
+      'ko': '한국어'
+    },
+    
+    changeFact: '別の冷知識',
+    share: 'シェア',
+    
+    loading: '読み込み中...',
+    noFactToday: '今日の冷知識はありません',
+    fallbackMessage: '今日の冷知識はまだありません、明日また来てください！',
+    
+    todayFact: '今日の冷知識',
+    noFactTodayHeader: '今日の冷知識なし',
+    
+    seeYouTomorrow: 'また明日！',
+    tomorrowMessage: '明日も新しい冷知識があなたを待っています、また来てくださいね！',
+    timeUntilTomorrow: '明日まで',
+    onTimeUpdate: '定時更新',
+    
+    shareSuccess: 'リンクがクリップボードにコピーされました！',
+    
+    copyright: '© 2024 毎日の冷知識. 全著作権所有.',
+    footerTagline: '毎日を驚きと新しい知識で満たしましょう',
+    
+    topAdZone: 'トップ広告エリア',
+    middleAdZone: 'コンテンツ広告エリア',
+    bottomAdZone: 'ボトム広告エリア'
+  },
+  
+  'ko': {
+    title: 'DAILY FACT',
+    subtitle: '매일의 냉지식',
+    tagline: '매일 하나의 냉지식으로 삶을 더욱 재미있게',
+    
+    languages: {
+      'zh-TW': '繁體中文',
+      'zh-CN': '简体中文',
+      'en': 'English',
+      'ja': '日本語',
+      'ko': '한국어'
+    },
+    
+    changeFact: '다른 냉지식',
+    share: '공유',
+    
+    loading: '로딩 중...',
+    noFactToday: '오늘의 냉지식이 없습니다',
+    fallbackMessage: '오늘의 냉지식이 아직 없습니다, 내일 다시 와주세요!',
+    
+    todayFact: '오늘의 냉지식',
+    noFactTodayHeader: '오늘 냉지식 없음',
+    
+    seeYouTomorrow: '내일 봐요!',
+    tomorrowMessage: '내일도 새로운 냉지식이 당신을 기다리고 있습니다, 다시 와주세요!',
+    timeUntilTomorrow: '내일까지',
+    onTimeUpdate: '정시 업데이트',
+    
+    shareSuccess: '링크가 클립보드에 복사되었습니다!',
+    
+    copyright: '© 2024 매일의 냉지식. 모든 권리 보유.',
+    footerTagline: '매일을 놀라움과 새로운 지식으로 가득 채우세요',
+    
+    topAdZone: '상단 광고 영역',
+    middleAdZone: '콘텐츠 광고 영역',
+    bottomAdZone: '하단 광고 영역'
+  }
+};
+
+export function useTranslation(lang: Language) {
+  const t = (key: string) => {
+    const keys = key.split('.');
+    let value: unknown = translations[lang];
+    
+    for (const k of keys) {
+      value = (value as Record<string, unknown>)?.[k];
+    }
+    
+    return (value as string) || key;
+  };
+  
+  return { t };
+} 

--- a/src/utils/facts.ts
+++ b/src/utils/facts.ts
@@ -1,0 +1,29 @@
+import facts from '@/data/facts.json';
+
+export type Fact = typeof facts[number];
+export type Language = 'zh-TW' | 'zh-CN' | 'en' | 'ja' | 'ko';
+
+export function getFactByDate(date: string, lang: Language) {
+  const fact = facts.find((f) => f.date === date);
+  if (!fact) return null;
+  const localized = fact.translations[lang] || fact.translations['zh-TW'];
+  return {
+    id: fact.id,
+    date: fact.date,
+    text: localized,
+    source: fact.source || '',
+  };
+}
+
+export function getRandomFact(lang: Language) {
+  if (!facts.length) return null;
+  const idx = Math.floor(Math.random() * facts.length);
+  const fact = facts[idx];
+  const localized = fact.translations[lang] || fact.translations['zh-TW'];
+  return {
+    id: fact.id,
+    date: fact.date,
+    text: localized,
+    source: fact.source || '',
+  };
+} 


### PR DESCRIPTION
## 🤔 為什麼要有這隻 PR?
- 原本的冷知識系統只顯示靜態內容，無法根據實際日期顯示對應的冷知識
- 缺少多語言支援，所有文字都是 hard-coded，不利於國際化
- 沒有隨機冷知識功能，使用者體驗較為單調
- 缺少錯誤處理機制，當找不到對應日期的冷知識時沒有友善的提示

## 🚀 這支 PR 做了什麼?
- 核心功能實作
  - 日期導向顯示：根據今天日期從 `facts.json` 中找出對應冷知識顯示
  - 多語言支援：建立完整的 i18n 系統，支援繁體中文、简体中文、English、日本語、한국어
  - 隨機冷知識：新增「換一則冷知識」按鈕，可隨機顯示其他冷知識
  - 錯誤處理：當找不到該日期冷知識時，顯示友善的 fallback 訊息
- 架構重構
  - `Utility Functions`：將冷知識查詢邏輯抽成 `src/utils/facts.ts`，提供 `getFactByDate()` 和 `getRandomFact()` 方法
  - API 擴充：修改 `app/api/fact/route.ts`，支援 `?random=1` 參數取得隨機冷知識
  - i18n 系統：建立 `src/i18n/translations.ts`，統一管理所有靜態文字翻譯 
- UI/UX 改善
  - 語系切換：實作完整的語言選擇器，所有文字即時更新
  - 日期格式化：使用 `Intl.DateTimeFormat` 根據使用者語言顯示本地化日期
  - SEO 優化：統一主標題為單一 `<h1>` 標籤，移除重複的英文標題
  - 動畫效果：保留並改善標題動畫 icon，提升視覺體驗
- 資料擴充
  - 冷知識資料：在 `data/facts.json` 中新增 2025-07-05 和 2025-07-06 的冷知識
  - 多語言內容：每則冷知識都包含五種語言的翻譯版本

## 📝 補充說明
- 重新整理頁面會回到今日冷知識，隨機功能只在當次 session 有效
- 所有靜態文字都已綁定到 i18n 系統，未來新增語言只需在 `translations.ts` 中新增對應翻譯
- 日期顯示會根據使用者語言自動調整格式