### PR TITLE
🐛 🔧 修正 AdSense 驗證在 Next.js App Router 中的問題

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,37 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 4. 點擊「驗證」按鈕
 5. 等待 Google 系統檢查您的網站
 
-### 4. 審核時間
+### 4. AdSense 驗證失敗的常見原因
+
+如果您遇到 AdSense 驗證失敗的問題，請檢查以下常見原因：
+
+#### 🔧 Next.js App Router 架構問題
+- **問題**：如果使用 Next.js App Router 架構，直接在 `app/head.tsx` 放 `<script>` 標籤並不會出現在最終的 HTML 中
+- **解決方案**：應改用 `next/script` 提供的 `<Script>` 元件來插入 AdSense 驗證碼
+
+```tsx
+import Script from 'next/script';
+
+// 在 head.tsx 中使用
+<Script
+  async
+  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-YOUR_PUBLISHER_ID"
+  crossOrigin="anonymous"
+  strategy="afterInteractive"
+/>
+```
+
+#### 🚀 部署和驗證步驟
+1. 插入驗證碼後，記得重新部署網站
+2. 部署完成後，在 AdSense 後台按下「驗證」按鈕
+3. 確保驗證碼在網站原始碼中可見（可以按 F12 查看網頁原始碼）
+
+#### 📋 其他檢查項目
+- 確認 Publisher ID 是否正確
+- 確認網站是否正常運作且可公開訪問
+- 確認網站內容符合 AdSense 政策
+
+### 5. 審核時間
 
 - Google AdSense 審核通常需要 **1～3 個工作天**
 - 審核期間請確保網站正常運作

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Script from 'next/script';
 import { Language } from '../src/i18n/translations';
 import { getCurrentLanguage, languageToOgLocale } from '../src/utils/language';
 
@@ -66,11 +67,12 @@ export default function Head() {
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       
       {/* Google AdSense 驗證程式碼 */}
-      <script
+      <Script
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1281401893626384"
         crossOrigin="anonymous"
-      ></script>
+        strategy="afterInteractive"
+      />
       
       {/* Favicon 設定 */}
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## 🤔 為什麼要有這隻 PR?
- 原本在 `app/head.tsx` 中直接使用 `<script>` 標籤插入 AdSense 驗證碼，但在 Next.js App Router 架構下不會出現在最終的 HTML 中
- 這會導致 Google AdSense 驗證失敗，影響廣告功能的正常運作
- 需要改用 Next.js 官方推薦的 Script 元件來確保驗證碼正確載入

## 🚀 這支 PR 做了什麼?
- 修改 `app/head.tsx`
  - 新增 import Script from `next/script`
  - 將原本的 `<script>` 標籤替換為 `<Script>` 元件
  - 加入 `strategy="afterInteractive"` 屬性以優化載入效能
- 更新 `README.md`
  - 新增「AdSense 驗證失敗的常見原因」章節
  - 詳細說明 Next.js App Router 架構下的特殊問題
  - 提供正確的解決方案和程式碼範例
  - 加入部署和驗證步驟的提醒
  - 列出其他常見檢查項目

## 📝 補充說明
- 使用 `strategy="afterInteractive"` 確保 AdSense 程式碼在頁面互動後才載入，不會影響初始載入效能
- 修改後需要重新部署網站，並在 AdSense 後台重新驗證
- 這個修正可以幫助其他使用 Next.js App Router 的開發者避免相同的驗證問題