### PR TITLE
🐛 修復 AdSense 驗證程式碼靜態插入問題

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,24 +76,48 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 4. 點擊「驗證」按鈕
 5. 等待 Google 系統檢查您的網站
 
-### 4. AdSense 驗證失敗的常見原因
+### 4. AdSense 驗證注意事項
+
+#### 🔍 AdSense 驗證機制說明
+- **重要**：AdSense 的驗證機制是透過 bot 讀取 HTML 靜態內容，不會等待 JavaScript 載入
+- **問題**：使用 `<Script>` 或 `afterInteractive` 的方式，驗證時 script 可能無法被掃描到
+- **解決方案**：因此建議使用 `next/head` 提供的 `<Head>` 元件靜態插入驗證 `<script>`，確保出現在初始 HTML 中
+
+#### 📝 目前使用的驗證程式碼
+```tsx
+import Head from 'next/head';
+
+// 在 Head 元件中使用
+<Head>
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1281401893626384"
+    crossOrigin="anonymous"
+  ></script>
+</Head>
+```
+
+**注意**：`ca-pub-1281401893626384` 僅作為範例可見，實際使用時請替換為您的 Publisher ID。
+
+### 5. AdSense 驗證失敗的常見原因
 
 如果您遇到 AdSense 驗證失敗的問題，請檢查以下常見原因：
 
 #### 🔧 Next.js App Router 架構問題
 - **問題**：如果使用 Next.js App Router 架構，直接在 `app/head.tsx` 放 `<script>` 標籤並不會出現在最終的 HTML 中
-- **解決方案**：應改用 `next/script` 提供的 `<Script>` 元件來插入 AdSense 驗證碼
+- **解決方案**：應改用 `next/head` 提供的 `<Head>` 元件來插入 AdSense 驗證碼
 
 ```tsx
-import Script from 'next/script';
+import Head from 'next/head';
 
 // 在 head.tsx 中使用
-<Script
-  async
-  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-YOUR_PUBLISHER_ID"
-  crossOrigin="anonymous"
-  strategy="afterInteractive"
-/>
+<Head>
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-YOUR_PUBLISHER_ID"
+    crossOrigin="anonymous"
+  ></script>
+</Head>
 ```
 
 #### 🚀 部署和驗證步驟
@@ -106,7 +130,7 @@ import Script from 'next/script';
 - 確認網站是否正常運作且可公開訪問
 - 確認網站內容符合 AdSense 政策
 
-### 5. 審核時間
+### 6. 審核時間
 
 - Google AdSense 審核通常需要 **1～3 個工作天**
 - 審核期間請確保網站正常運作

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Script from 'next/script';
+import Head from 'next/head';
 import { Language } from '../src/i18n/translations';
 import { getCurrentLanguage, languageToOgLocale } from '../src/utils/language';
 
@@ -34,7 +34,7 @@ const siteMetadata: Record<Language, { title: string; description: string; siteN
   }
 };
 
-export default function Head() {
+export default function HeadComponent() {
   const [currentLanguage, setCurrentLanguage] = useState<Language>('zh-TW');
   const [metadata, setMetadata] = useState(siteMetadata['zh-TW']);
 
@@ -62,79 +62,80 @@ export default function Head() {
 
   return (
     <>
-      <title>{metadata.title}</title>
-      <meta name="description" content={metadata.description} />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      
-      {/* Google AdSense 驗證程式碼 */}
-      <Script
-        async
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1281401893626384"
-        crossOrigin="anonymous"
-        strategy="afterInteractive"
-      />
-      
-      {/* Favicon 設定 */}
-      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-      <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-      <link rel="manifest" href="/site.webmanifest" />
-      
-      {/* 應用程式設定 */}
-      <meta name="application-name" content={metadata.siteName} />
-      <meta name="theme-color" content="#fdf6e3" />
-      <meta name="msapplication-TileColor" content="#fdf6e3" />
-      <meta name="msapplication-config" content="/browserconfig.xml" />
-      
-      {/* 基本 SEO */}
-      <meta name="robots" content="index, follow" />
-      <meta name="author" content="Alen" />
-      <meta name="keywords" content="冷知識,每日知識,fun facts,日常知識,知識小品,daily fact" />
-      
-      {/* Canonical URL */}
-      <link rel="canonical" href={getFullUrl()} />
+      <Head>
+        <title>{metadata.title}</title>
+        <meta name="description" content={metadata.description} />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        
+        {/* Google AdSense 驗證程式碼 */}
+        <script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1281401893626384"
+          crossOrigin="anonymous"
+        ></script>
+        
+        {/* Favicon 設定 */}
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+        <link rel="manifest" href="/site.webmanifest" />
+        
+        {/* 應用程式設定 */}
+        <meta name="application-name" content={metadata.siteName} />
+        <meta name="theme-color" content="#fdf6e3" />
+        <meta name="msapplication-TileColor" content="#fdf6e3" />
+        <meta name="msapplication-config" content="/browserconfig.xml" />
+        
+        {/* 基本 SEO */}
+        <meta name="robots" content="index, follow" />
+        <meta name="author" content="Alen" />
+        <meta name="keywords" content="冷知識,每日知識,fun facts,日常知識,知識小品,daily fact" />
+        
+        {/* Canonical URL */}
+        <link rel="canonical" href={getFullUrl()} />
 
-      {/* Open Graph / Facebook */}
-      <meta property="og:type" content="website" />
-      <meta property="og:url" content={getFullUrl()} />
-      <meta property="og:title" content={metadata.title} />
-      <meta property="og:description" content={metadata.description} />
-      <meta property="og:image" content={getImageUrl()} />
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="630" />
-      <meta property="og:image:alt" content={metadata.title} />
-      <meta property="og:site_name" content={metadata.siteName} />
-      <meta property="og:locale" content={languageToOgLocale[currentLanguage]} />
-      
-      {/* Open Graph 多語言替代版本 */}
-      <meta property="og:locale:alternate" content="zh_TW" />
-      <meta property="og:locale:alternate" content="zh_CN" />
-      <meta property="og:locale:alternate" content="en_US" />
-      <meta property="og:locale:alternate" content="ja_JP" />
-      <meta property="og:locale:alternate" content="ko_KR" />
+        {/* Open Graph / Facebook */}
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={getFullUrl()} />
+        <meta property="og:title" content={metadata.title} />
+        <meta property="og:description" content={metadata.description} />
+        <meta property="og:image" content={getImageUrl()} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:alt" content={metadata.title} />
+        <meta property="og:site_name" content={metadata.siteName} />
+        <meta property="og:locale" content={languageToOgLocale[currentLanguage]} />
+        
+        {/* Open Graph 多語言替代版本 */}
+        <meta property="og:locale:alternate" content="zh_TW" />
+        <meta property="og:locale:alternate" content="zh_CN" />
+        <meta property="og:locale:alternate" content="en_US" />
+        <meta property="og:locale:alternate" content="ja_JP" />
+        <meta property="og:locale:alternate" content="ko_KR" />
 
-      {/* Twitter Card */}
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:site" content="@yourtwitterhandle" />
-      <meta name="twitter:creator" content="@yourtwitterhandle" />
-      <meta name="twitter:title" content={metadata.title} />
-      <meta name="twitter:description" content={metadata.description} />
-      <meta name="twitter:image" content={getImageUrl()} />
-      <meta name="twitter:image:alt" content={metadata.title} />
+        {/* Twitter Card */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@yourtwitterhandle" />
+        <meta name="twitter:creator" content="@yourtwitterhandle" />
+        <meta name="twitter:title" content={metadata.title} />
+        <meta name="twitter:description" content={metadata.description} />
+        <meta name="twitter:image" content={getImageUrl()} />
+        <meta name="twitter:image:alt" content={metadata.title} />
 
-      {/* LINE 分享優化 */}
-      <meta property="og:image:type" content="image/png" />
-      <meta property="og:image:secure_url" content={getImageUrl()} />
+        {/* LINE 分享優化 */}
+        <meta property="og:image:type" content="image/png" />
+        <meta property="og:image:secure_url" content={getImageUrl()} />
 
-      {/* Apple 行動裝置優化 */}
-      <meta name="apple-mobile-web-app-capable" content="yes" />
-      <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-      <meta name="apple-mobile-web-app-title" content={metadata.siteName} />
-      
-      {/* 預載入圖片以改善分享效能 */}
-      <link rel="preload" as="image" href="/og-image.png" />
+        {/* Apple 行動裝置優化 */}
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content={metadata.siteName} />
+        
+        {/* 預載入圖片以改善分享效能 */}
+        <link rel="preload" as="image" href="/og-image.png" />
+      </Head>
     </>
   );
 }


### PR DESCRIPTION
## 🤔 為什麼要有這隻 PR?
- Google AdSense 的驗證機制是透過 bot 讀取 HTML 靜態內容，不會等待 JavaScript 載入。原本使用 next/script 的 `<Script>` 元件搭配 `strategy="afterInteractive"` 的方式，在驗證時 script 可能無法被掃描到，導致 AdSense 驗證失敗。

## 🚀 這支 PR 做了什麼?
- 修改 `app/head.tsx`
  - 將 import Script from 'next/script' 改為 import Head from 'next/head'
  - 將元件名稱從 `Head` 改為 `HeadComponent` 以避免命名衝突
  - 移除原本的 `<Script strategy="afterInteractive" ... />` 元件
  - 改用 next/head 的 `<Head>` 元件靜態插入 AdSense 驗證 `<script>` 標籤
  - 確保驗證程式碼出現在初始 HTML 中，能被 AdSense bot 正確掃描
- 更新 `README.md`
  - 新增「AdSense 驗證注意事項」段落，詳細說明驗證機制
  - 解釋為什麼需要使用靜態插入而非動態載入
  - 提供正確的程式碼範例和實作方式
  - 更新常見問題解決方案，將 `<Script>` 改為 `<Head>` 元件
  - 包含目前使用的 client ID 範例：`ca-pub-1281401893626384`

## 📝 補充說明
- 這次修改確保了 AdSense 驗證程式碼能夠在 HTML 層級被正確渲染，解決了 Next.js App Router 架構下動態載入 script 可能導致的驗證失敗問題。文件更新也讓其他開發者能夠理解為什麼要使用這種實作方式。